### PR TITLE
feat(error-handling): implement comprehensive error handling system

### DIFF
--- a/examples/enhanced_error_handling_demo.rs
+++ b/examples/enhanced_error_handling_demo.rs
@@ -1,0 +1,361 @@
+/// Example demonstrating enhanced GraphQL error handling capabilities
+/// This example shows various error types, propagation, formatting, and best practices
+use graphql_rs::domain::value_objects::{
+    ErrorFormatter, ErrorPropagation, ExecutionResult, GraphQLError, PathSegment, ValidationResult,
+};
+use serde_json::json;
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    println!("🚀 GraphQL Enhanced Error Handling Demo");
+    println!("==========================================");
+
+    // 1. Demonstrate different error types
+    demo_error_types();
+
+    // 2. Demonstrate error enhancement
+    demo_error_enhancement();
+
+    // 3. Demonstrate error propagation
+    demo_error_propagation();
+
+    // 4. Demonstrate error formatting
+    demo_error_formatting();
+
+    // 5. Demonstrate execution results
+    demo_execution_results();
+
+    // 6. Demonstrate validation results
+    demo_validation_results();
+
+    // 7. Real-world scenario
+    demo_real_world_scenario().await;
+
+    println!("\n✅ Enhanced Error Handling Demo Complete!");
+    Ok(())
+}
+
+fn demo_error_types() {
+    println!("\n🔍 1. Different Error Types:");
+    println!("   ----------------------------");
+
+    // Client errors
+    let validation_error = GraphQLError::validation_error("Invalid query syntax".to_string());
+    let field_error = GraphQLError::field_not_found("unknownField", "Query");
+    let auth_error = GraphQLError::auth_error("Invalid authentication token".to_string());
+
+    // Server errors
+    let execution_error = GraphQLError::execution_error("Database connection failed".to_string());
+    let rate_limit_error = GraphQLError::rate_limit_error();
+
+    println!(
+        "   ✓ Validation Error: {} (Code: {})",
+        validation_error.message,
+        validation_error.error_code().unwrap_or("None")
+    );
+    println!(
+        "   ✓ Field Error: {} (Client: {})",
+        field_error.message,
+        field_error.is_client_error()
+    );
+    println!(
+        "   ✓ Auth Error: {} (Code: {})",
+        auth_error.message,
+        auth_error.error_code().unwrap_or("None")
+    );
+    println!(
+        "   ✓ Execution Error: {} (Server: {})",
+        execution_error.message,
+        execution_error.is_server_error()
+    );
+    println!(
+        "   ✓ Rate Limit Error: {} (Code: {})",
+        rate_limit_error.message,
+        rate_limit_error.error_code().unwrap_or("None")
+    );
+}
+
+fn demo_error_enhancement() {
+    println!("\n🔧 2. Error Enhancement:");
+    println!("   ----------------------");
+
+    let error = GraphQLError::field_not_found("name", "User")
+        .with_location(2, 15)
+        .with_path(vec![
+            PathSegment::Field("user".to_string()),
+            PathSegment::Index(0),
+            PathSegment::Field("name".to_string()),
+        ])
+        .with_timestamp()
+        .with_request_id("req-12345")
+        .with_extension("suggestion", json!("Did you mean 'username'?"));
+
+    println!(
+        "   ✓ Error with location: Line {}, Column {}",
+        error.locations[0].line, error.locations[0].column
+    );
+    println!("   ✓ Error with path: {:?}", error.path);
+    println!("   ✓ Error with extensions: request_id, timestamp, suggestion");
+
+    // Demonstrate user message masking
+    let server_error =
+        GraphQLError::execution_error("Database password leaked: secret123".to_string());
+    println!(
+        "   ✓ Server error (dev): {}",
+        server_error.user_message(false)
+    );
+    println!(
+        "   ✓ Server error (prod): {}",
+        server_error.user_message(true)
+    );
+}
+
+fn demo_error_propagation() {
+    println!("\n📡 3. Error Propagation:");
+    println!("   -----------------------");
+
+    // Non-nullable field error (bubbles up)
+    let error = GraphQLError::execution_error("Service unavailable".to_string());
+    let path = vec![
+        PathSegment::Field("user".to_string()),
+        PathSegment::Field("id".to_string()),
+    ];
+
+    let (_propagated_error, should_bubble) = ErrorPropagation::propagate_field_error(
+        error.clone(),
+        &path,
+        false, // non-nullable
+    );
+
+    println!(
+        "   ✓ Non-nullable field error bubbles up: {}",
+        should_bubble
+    );
+
+    // Nullable field error (doesn't bubble)
+    let (_, should_bubble_nullable) = ErrorPropagation::propagate_field_error(
+        error, &path, true, // nullable
+    );
+
+    println!(
+        "   ✓ Nullable field error bubbles up: {}",
+        should_bubble_nullable
+    );
+
+    // Missing required field
+    let missing_error = ErrorPropagation::missing_required_field(
+        "email",
+        &[PathSegment::Field("user".to_string())],
+    );
+    println!("   ✓ Missing required field: {}", missing_error.message);
+
+    // Null in non-nullable
+    let null_error =
+        ErrorPropagation::null_in_non_nullable("id", &[PathSegment::Field("user".to_string())]);
+    println!("   ✓ Null in non-nullable: {}", null_error.message);
+}
+
+fn demo_error_formatting() {
+    println!("\n🎨 4. Error Formatting:");
+    println!("   ----------------------");
+
+    let error = GraphQLError::execution_error("Internal service failure".to_string())
+        .with_location(3, 7)
+        .with_path(vec![
+            PathSegment::Field("users".to_string()),
+            PathSegment::Index(1),
+        ])
+        .with_extension("stackTrace", json!(["service.rs:42", "handler.rs:15"]));
+
+    // Development formatting (full details)
+    let _dev_format = ErrorFormatter::format_development(&error);
+    println!("   ✓ Development format includes: message, locations, path, stackTrace");
+
+    // Production formatting (sanitized)
+    let _prod_format = ErrorFormatter::format_production(&error);
+    println!("   ✓ Production format masks sensitive info");
+
+    // Error summary
+    let errors = vec![
+        GraphQLError::validation_error("Error 1".to_string()),
+        GraphQLError::field_not_found("field", "Type"),
+        GraphQLError::execution_error("Error 2".to_string()),
+    ];
+
+    let summary = ErrorFormatter::format_error_summary(&errors);
+    println!(
+        "   ✓ Error summary: {} total, {} client, {} server",
+        summary["total"], summary["client_errors"], summary["server_errors"]
+    );
+}
+
+fn demo_execution_results() {
+    println!("\n⚡ 5. Execution Results:");
+    println!("   ----------------------");
+
+    // Success result
+    let success =
+        ExecutionResult::success(json!({"user": {"name": "John", "email": "john@example.com"}}))
+            .with_timing(125)
+            .with_tracing("trace-abc123");
+
+    println!(
+        "   ✓ Success result: is_success={}, has_errors={}",
+        success.is_success(),
+        success.has_errors()
+    );
+
+    // Error result
+    let error_result =
+        ExecutionResult::single_error(GraphQLError::field_not_found("unknownField", "Query"));
+
+    println!(
+        "   ✓ Error result: is_success={}, has_errors={}",
+        error_result.is_success(),
+        error_result.has_errors()
+    );
+
+    // Partial result (data + errors)
+    let partial = ExecutionResult::partial(
+        json!({"user": {"name": "John", "email": null}}),
+        vec![GraphQLError::execution_error(
+            "Email service unavailable".to_string(),
+        )],
+    );
+
+    println!(
+        "   ✓ Partial result: has_data={}, has_errors={}",
+        partial.data.is_some(),
+        partial.has_errors()
+    );
+
+    // Result with mixed error types
+    let mixed = ExecutionResult::success(json!({}))
+        .with_error(GraphQLError::validation_error("Client error".to_string()))
+        .with_error(GraphQLError::execution_error("Server error".to_string()));
+
+    println!(
+        "   ✓ Mixed errors: client_errors={}, server_errors={}",
+        mixed.has_client_errors(),
+        mixed.has_server_errors()
+    );
+
+    // Sanitized result for production
+    let _sanitized = mixed.sanitized(true);
+    println!("   ✓ Sanitized result masks server error messages");
+}
+
+fn demo_validation_results() {
+    println!("\n✅ 6. Validation Results:");
+    println!("   -------------------------");
+
+    // Valid result
+    let valid = ValidationResult::valid();
+    println!("   ✓ Valid result: {}", valid.is_valid());
+
+    // Invalid with field error
+    let field_invalid = ValidationResult::field_error("name", "Field is required".to_string());
+    println!(
+        "   ✓ Field error has path: {}",
+        field_invalid.errors().unwrap()[0].path.is_some()
+    );
+
+    // Type error
+    let type_invalid = ValidationResult::type_error("User", "Invalid type definition".to_string());
+    println!(
+        "   ✓ Type error has type extension: {}",
+        type_invalid.errors().unwrap()[0].extensions.is_some()
+    );
+
+    // Combine multiple results
+    let combined = ValidationResult::combine(vec![
+        ValidationResult::valid(),
+        ValidationResult::invalid("Error 1".to_string()),
+        ValidationResult::field_error("field", "Error 2".to_string()),
+    ]);
+
+    if let Some(errors) = combined.errors() {
+        println!("   ✓ Combined result has {} errors", errors.len());
+    }
+
+    // Convert to execution result
+    if let Some(exec_result) = combined.to_execution_result() {
+        println!(
+            "   ✓ Converted to execution result with {} errors",
+            exec_result.errors.len()
+        );
+    }
+}
+
+async fn demo_real_world_scenario() {
+    println!("\n🌍 7. Real-World Scenario:");
+    println!("   --------------------------");
+
+    // Simulate a GraphQL query execution with various errors
+    let mut result = ExecutionResult::success(json!({}));
+
+    // Add some validation errors during parsing
+    result = result.with_error(
+        GraphQLError::validation_error("Unknown directive '@unknownDirective'".to_string())
+            .with_location(1, 20),
+    );
+
+    // Add a field resolution error
+    result = result.with_error(
+        GraphQLError::field_not_found("profile", "User")
+            .with_location(2, 8)
+            .with_path(vec![PathSegment::Field("user".to_string())])
+            .with_extension("suggestion", json!("Did you mean 'userProfile'?")),
+    );
+
+    // Add an execution error from a resolver
+    result = result.with_error(
+        GraphQLError::execution_error("External API timeout".to_string())
+            .with_path(vec![
+                PathSegment::Field("user".to_string()),
+                PathSegment::Field("posts".to_string()),
+                PathSegment::Index(0),
+            ])
+            .with_timestamp()
+            .with_request_id("req-xyz789"),
+    );
+
+    // Add execution metadata
+    result = result.with_timing(450).with_tracing("trace-real-world-123");
+
+    println!("   ✓ Complex query result:");
+    println!("     - Total errors: {}", result.errors.len());
+    println!("     - Client errors: {}", result.has_client_errors());
+    println!("     - Server errors: {}", result.has_server_errors());
+    println!("     - Has timing info: {}", result.extensions.is_some());
+
+    // Show different formatting approaches
+    println!("\n   📊 Error Analysis:");
+    let summary = ErrorFormatter::format_error_summary(&result.errors);
+    println!(
+        "     - Validation errors: {}",
+        summary["by_code"]
+            .get("VALIDATION_ERROR")
+            .unwrap_or(&json!(0))
+    );
+    println!(
+        "     - Field errors: {}",
+        summary["by_code"]
+            .get("FIELD_NOT_FOUND")
+            .unwrap_or(&json!(0))
+    );
+    println!(
+        "     - Execution errors: {}",
+        summary["by_code"]
+            .get("EXECUTION_ERROR")
+            .unwrap_or(&json!(0))
+    );
+
+    // Show sanitized version for production
+    let _sanitized = result.sanitized(true);
+    println!("\n   🔒 Production Response (sanitized):");
+    println!("     - Client errors shown as-is");
+    println!("     - Server errors masked for security");
+    println!("     - Timing and tracing info preserved");
+}

--- a/src/domain/services.rs
+++ b/src/domain/services.rs
@@ -25,36 +25,42 @@ impl SchemaValidator {
 
         // Rule 1: Schema must have a Query type
         if schema.get_type(&schema.query_type).is_none() {
-            errors.push(GraphQLError::validation_error(format!(
-                "Query type '{}' is not defined",
-                schema.query_type
-            )));
+            errors.push(
+                GraphQLError::type_not_found(&schema.query_type).with_extension(
+                    "rule",
+                    serde_json::Value::String("QUERY_TYPE_REQUIRED".to_string()),
+                ),
+            );
         }
 
         // Rule 2: Mutation type must exist if specified
         if let Some(mutation_type) = &schema.mutation_type {
             if schema.get_type(mutation_type).is_none() {
-                errors.push(GraphQLError::validation_error(format!(
-                    "Mutation type '{mutation_type}' is not defined"
-                )));
+                errors.push(GraphQLError::type_not_found(mutation_type).with_extension(
+                    "rule",
+                    serde_json::Value::String("MUTATION_TYPE_REQUIRED".to_string()),
+                ));
             }
         }
 
         // Rule 3: Subscription type must exist if specified
         if let Some(subscription_type) = &schema.subscription_type {
             if schema.get_type(subscription_type).is_none() {
-                errors.push(GraphQLError::validation_error(format!(
-                    "Subscription type '{subscription_type}' is not defined"
-                )));
+                errors.push(
+                    GraphQLError::type_not_found(subscription_type).with_extension(
+                        "rule",
+                        serde_json::Value::String("SUBSCRIPTION_TYPE_REQUIRED".to_string()),
+                    ),
+                );
             }
         }
 
         // Additional validation rules will be added in later iterations
 
         if errors.is_empty() {
-            ValidationResult::Valid
+            ValidationResult::valid()
         } else {
-            ValidationResult::Invalid(errors)
+            ValidationResult::invalid_with_errors(errors)
         }
     }
 }

--- a/src/domain/value_objects.rs
+++ b/src/domain/value_objects.rs
@@ -183,16 +183,71 @@ impl ValidationResult {
         Self::Valid
     }
 
-    /// Create an invalid result with a single error
+    /// Create an invalid result with a single error message
     #[must_use]
     pub fn invalid(error: String) -> Self {
-        Self::Invalid(vec![GraphQLError::new(error)])
+        Self::Invalid(vec![GraphQLError::validation_error(error)])
+    }
+
+    /// Create an invalid result with a single GraphQLError
+    #[must_use]
+    pub fn invalid_with_error(error: GraphQLError) -> Self {
+        Self::Invalid(vec![error])
     }
 
     /// Create an invalid result with multiple errors
     #[must_use]
     pub fn invalid_with_errors(errors: Vec<GraphQLError>) -> Self {
         Self::Invalid(errors)
+    }
+
+    /// Create a validation error for a specific field
+    #[must_use]
+    pub fn field_error(field_name: &str, message: String) -> Self {
+        let error = GraphQLError::validation_error(message)
+            .with_path(vec![PathSegment::Field(field_name.to_string())]);
+        Self::Invalid(vec![error])
+    }
+
+    /// Create a validation error for a type
+    #[must_use]
+    pub fn type_error(type_name: &str, message: String) -> Self {
+        let error = GraphQLError::validation_error(message)
+            .with_extension("type", serde_json::Value::String(type_name.to_string()));
+        Self::Invalid(vec![error])
+    }
+
+    /// Combine multiple validation results
+    #[must_use]
+    pub fn combine(results: Vec<ValidationResult>) -> Self {
+        let mut all_errors = Vec::new();
+
+        for result in results {
+            match result {
+                Self::Invalid(errors) => all_errors.extend(errors),
+                Self::Valid => continue,
+                Self::Pending => return Self::Pending, // If any is pending, result is pending
+            }
+        }
+
+        if all_errors.is_empty() {
+            Self::Valid
+        } else {
+            Self::Invalid(all_errors)
+        }
+    }
+
+    /// Add an error to an existing result
+    #[must_use]
+    pub fn with_error(self, error: GraphQLError) -> Self {
+        match self {
+            Self::Valid => Self::Invalid(vec![error]),
+            Self::Invalid(mut errors) => {
+                errors.push(error);
+                Self::Invalid(errors)
+            },
+            Self::Pending => Self::Pending, // Pending stays pending
+        }
     }
 
     /// Check if the validation result is valid
@@ -205,6 +260,30 @@ impl ValidationResult {
     #[must_use]
     pub fn is_invalid(&self) -> bool {
         matches!(self, Self::Invalid(_))
+    }
+
+    /// Check if the validation result is pending
+    #[must_use]
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending)
+    }
+
+    /// Get the errors if invalid
+    #[must_use]
+    pub fn errors(&self) -> Option<&Vec<GraphQLError>> {
+        match self {
+            Self::Invalid(errors) => Some(errors),
+            _ => None,
+        }
+    }
+
+    /// Convert to ExecutionResult if invalid
+    #[must_use]
+    pub fn to_execution_result(self) -> Option<ExecutionResult> {
+        match self {
+            Self::Invalid(errors) => Some(ExecutionResult::error(errors)),
+            _ => None,
+        }
     }
 }
 
@@ -242,6 +321,36 @@ impl ExecutionResult {
         }
     }
 
+    /// Create an execution result with a single error
+    #[must_use]
+    pub fn single_error(error: GraphQLError) -> Self {
+        Self::error(vec![error])
+    }
+
+    /// Create a partial result with both data and errors
+    #[must_use]
+    pub fn partial(data: serde_json::Value, errors: Vec<GraphQLError>) -> Self {
+        Self {
+            data: Some(data),
+            errors,
+            extensions: None,
+        }
+    }
+
+    /// Add an error to the result
+    #[must_use]
+    pub fn with_error(mut self, error: GraphQLError) -> Self {
+        self.errors.push(error);
+        self
+    }
+
+    /// Add multiple errors to the result
+    #[must_use]
+    pub fn with_errors(mut self, mut errors: Vec<GraphQLError>) -> Self {
+        self.errors.append(&mut errors);
+        self
+    }
+
     /// Add an extension to the result
     #[must_use]
     pub fn with_extension(mut self, key: String, value: serde_json::Value) -> Self {
@@ -250,6 +359,86 @@ impl ExecutionResult {
         }
         self.extensions.as_mut().unwrap().insert(key, value);
         self
+    }
+
+    /// Add execution timing information
+    #[must_use]
+    pub fn with_timing(self, duration_ms: u64) -> Self {
+        self.with_extension(
+            "timing".to_string(),
+            serde_json::json!({
+                "duration_ms": duration_ms
+            }),
+        )
+    }
+
+    /// Add tracing information
+    #[must_use]
+    pub fn with_tracing(self, trace_id: &str) -> Self {
+        self.with_extension(
+            "tracing".to_string(),
+            serde_json::json!({
+                "trace_id": trace_id
+            }),
+        )
+    }
+
+    /// Check if the result has any errors
+    #[must_use]
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    /// Check if the result is successful (no errors)
+    #[must_use]
+    pub fn is_success(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    /// Get errors by type
+    #[must_use]
+    pub fn errors_by_code(&self, code: &str) -> Vec<&GraphQLError> {
+        self.errors
+            .iter()
+            .filter(|error| error.error_code() == Some(code))
+            .collect()
+    }
+
+    /// Check if result has client errors
+    #[must_use]
+    pub fn has_client_errors(&self) -> bool {
+        self.errors.iter().any(|error| error.is_client_error())
+    }
+
+    /// Check if result has server errors
+    #[must_use]
+    pub fn has_server_errors(&self) -> bool {
+        self.errors.iter().any(|error| error.is_server_error())
+    }
+
+    /// Create a sanitized version for production (mask server errors)
+    #[must_use]
+    pub fn sanitized(&self, mask_server_errors: bool) -> Self {
+        if !mask_server_errors {
+            return self.clone();
+        }
+
+        let sanitized_errors = self
+            .errors
+            .iter()
+            .map(|error| GraphQLError {
+                message: error.user_message(mask_server_errors),
+                locations: error.locations.clone(),
+                path: error.path.clone(),
+                extensions: error.extensions.clone(),
+            })
+            .collect();
+
+        Self {
+            data: self.data.clone(),
+            errors: sanitized_errors,
+            extensions: self.extensions.clone(),
+        }
     }
 }
 
@@ -300,10 +489,55 @@ impl GraphQLError {
         }
     }
 
-    /// Create a validation error
+    /// Create a validation error with error code
     #[must_use]
     pub fn validation_error(message: String) -> Self {
-        Self::new(message)
+        Self::new(message).with_error_code("VALIDATION_ERROR")
+    }
+
+    /// Create a parse error
+    #[must_use]
+    pub fn parse_error(message: String) -> Self {
+        Self::new(message).with_error_code("PARSE_ERROR")
+    }
+
+    /// Create a field not found error
+    #[must_use]
+    pub fn field_not_found(field_name: &str, type_name: &str) -> Self {
+        Self::new(format!(
+            "Field '{field_name}' not found on type '{type_name}'"
+        ))
+        .with_error_code("FIELD_NOT_FOUND")
+    }
+
+    /// Create a type not found error
+    #[must_use]
+    pub fn type_not_found(type_name: &str) -> Self {
+        Self::new(format!("Type '{type_name}' not found")).with_error_code("TYPE_NOT_FOUND")
+    }
+
+    /// Create an execution error
+    #[must_use]
+    pub fn execution_error(message: String) -> Self {
+        Self::new(message).with_error_code("EXECUTION_ERROR")
+    }
+
+    /// Create an authentication error
+    #[must_use]
+    pub fn auth_error(message: String) -> Self {
+        Self::new(message).with_error_code("AUTH_ERROR")
+    }
+
+    /// Create an authorization error
+    #[must_use]
+    pub fn authorization_error(message: String) -> Self {
+        Self::new(message).with_error_code("AUTHORIZATION_ERROR")
+    }
+
+    /// Create a rate limit error
+    #[must_use]
+    pub fn rate_limit_error() -> Self {
+        Self::new("Rate limit exceeded".to_string()).with_error_code("RATE_LIMIT_EXCEEDED")
     }
 
     /// Add a source location to the error
@@ -313,10 +547,214 @@ impl GraphQLError {
         self
     }
 
+    /// Add multiple source locations to the error
+    #[must_use]
+    pub fn with_locations(mut self, locations: Vec<SourceLocation>) -> Self {
+        self.locations.extend(locations);
+        self
+    }
+
     /// Add a path to the error
     #[must_use]
     pub fn with_path(mut self, path: Vec<PathSegment>) -> Self {
         self.path = Some(path);
         self
     }
+
+    /// Add an extension to the error
+    #[must_use]
+    pub fn with_extension(mut self, key: &str, value: serde_json::Value) -> Self {
+        if self.extensions.is_none() {
+            self.extensions = Some(serde_json::Map::new());
+        }
+        self.extensions
+            .as_mut()
+            .unwrap()
+            .insert(key.to_string(), value);
+        self
+    }
+
+    /// Add an error code extension
+    #[must_use]
+    pub fn with_error_code(self, code: &str) -> Self {
+        self.with_extension("code", serde_json::Value::String(code.to_string()))
+    }
+
+    /// Add a timestamp extension
+    #[must_use]
+    pub fn with_timestamp(self) -> Self {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        self.with_extension("timestamp", serde_json::Value::Number(timestamp.into()))
+    }
+
+    /// Add request ID for tracing
+    #[must_use]
+    pub fn with_request_id(self, request_id: &str) -> Self {
+        self.with_extension(
+            "requestId",
+            serde_json::Value::String(request_id.to_string()),
+        )
+    }
+
+    /// Get the error code from extensions
+    #[must_use]
+    pub fn error_code(&self) -> Option<&str> {
+        self.extensions.as_ref()?.get("code")?.as_str()
+    }
+
+    /// Check if this is a client error (4xx equivalent)
+    #[must_use]
+    pub fn is_client_error(&self) -> bool {
+        matches!(
+            self.error_code(),
+            Some(
+                "VALIDATION_ERROR"
+                    | "PARSE_ERROR"
+                    | "FIELD_NOT_FOUND"
+                    | "TYPE_NOT_FOUND"
+                    | "AUTH_ERROR"
+                    | "AUTHORIZATION_ERROR"
+            )
+        )
+    }
+
+    /// Check if this is a server error (5xx equivalent)
+    #[must_use]
+    pub fn is_server_error(&self) -> bool {
+        matches!(
+            self.error_code(),
+            Some("EXECUTION_ERROR" | "INTERNAL_ERROR")
+        )
+    }
+
+    /// Convert to a user-friendly message (mask sensitive server errors in production)
+    #[must_use]
+    pub fn user_message(&self, mask_server_errors: bool) -> String {
+        if mask_server_errors && self.is_server_error() {
+            "Internal server error occurred".to_string()
+        } else {
+            self.message.clone()
+        }
+    }
 }
+
+/// Error propagation utilities for GraphQL execution
+pub struct ErrorPropagation;
+
+impl ErrorPropagation {
+    /// Propagate field error up the execution path
+    /// If a non-nullable field errors, it causes the parent to become null
+    pub fn propagate_field_error(
+        error: GraphQLError,
+        field_path: &[PathSegment],
+        is_nullable: bool,
+    ) -> (GraphQLError, bool) {
+        let error_with_path = error.with_path(field_path.to_vec());
+
+        // Non-nullable fields cause parent to become null (bubble up)
+        let should_bubble = !is_nullable;
+
+        (error_with_path, should_bubble)
+    }
+
+    /// Collect multiple field errors and determine if parent should be null
+    pub fn collect_field_errors(errors: Vec<(GraphQLError, bool)>) -> (Vec<GraphQLError>, bool) {
+        let should_bubble = errors.iter().any(|(_, bubble)| *bubble);
+        let collected_errors = errors.into_iter().map(|(error, _)| error).collect();
+
+        (collected_errors, should_bubble)
+    }
+
+    /// Create error for missing required field
+    pub fn missing_required_field(field_name: &str, parent_path: &[PathSegment]) -> GraphQLError {
+        let mut path = parent_path.to_vec();
+        path.push(PathSegment::Field(field_name.to_string()));
+
+        GraphQLError::validation_error(format!("Required field '{field_name}' is missing"))
+            .with_path(path)
+    }
+
+    /// Create error for null value in non-nullable field
+    pub fn null_in_non_nullable(field_name: &str, parent_path: &[PathSegment]) -> GraphQLError {
+        let mut path = parent_path.to_vec();
+        path.push(PathSegment::Field(field_name.to_string()));
+
+        GraphQLError::validation_error(format!(
+            "Cannot return null for non-nullable field '{field_name}'"
+        ))
+        .with_path(path)
+    }
+}
+
+/// Error formatting utilities
+pub struct ErrorFormatter;
+
+impl ErrorFormatter {
+    /// Format error for development (includes all details)
+    pub fn format_development(error: &GraphQLError) -> serde_json::Value {
+        serde_json::json!({
+            "message": error.message,
+            "locations": error.locations,
+            "path": error.path,
+            "extensions": error.extensions,
+            "stackTrace": error.extensions
+                .as_ref()
+                .and_then(|ext| ext.get("stackTrace"))
+        })
+    }
+
+    /// Format error for production (sanitized)
+    pub fn format_production(error: &GraphQLError) -> serde_json::Value {
+        serde_json::json!({
+            "message": error.user_message(true),
+            "locations": if error.is_client_error() { Some(&error.locations) } else { None },
+            "path": error.path,
+            "extensions": {
+                "code": error.error_code(),
+                "timestamp": error.extensions
+                    .as_ref()
+                    .and_then(|ext| ext.get("timestamp"))
+            }
+        })
+    }
+
+    /// Format multiple errors with summary
+    pub fn format_error_summary(errors: &[GraphQLError]) -> serde_json::Value {
+        let client_errors = errors.iter().filter(|e| e.is_client_error()).count();
+        let server_errors = errors.iter().filter(|e| e.is_server_error()).count();
+
+        serde_json::json!({
+            "total": errors.len(),
+            "client_errors": client_errors,
+            "server_errors": server_errors,
+            "by_code": Self::group_errors_by_code(errors)
+        })
+    }
+
+    /// Group errors by error code
+    fn group_errors_by_code(errors: &[GraphQLError]) -> serde_json::Map<String, serde_json::Value> {
+        use std::collections::HashMap;
+
+        let mut grouped: HashMap<String, usize> = HashMap::new();
+
+        for error in errors {
+            let code = error.error_code().unwrap_or("UNKNOWN").to_string();
+            *grouped.entry(code).or_insert(0) += 1;
+        }
+
+        grouped
+            .into_iter()
+            .map(|(k, v)| (k, serde_json::Value::Number(v.into())))
+            .collect()
+    }
+}
+
+/// Result type for operations that can fail with GraphQL errors
+pub type GraphQLResult<T> = Result<T, GraphQLError>;
+
+/// Result type for operations that can return multiple GraphQL errors
+pub type GraphQLMultiResult<T> = Result<T, Vec<GraphQLError>>;

--- a/tests/error_handling_tests.rs
+++ b/tests/error_handling_tests.rs
@@ -1,0 +1,516 @@
+/// Comprehensive tests for enhanced GraphQL error handling
+/// This test suite covers error creation, propagation, formatting, and edge cases
+use graphql_rs::domain::value_objects::{
+    ErrorFormatter, ErrorPropagation, ExecutionResult, GraphQLError, GraphQLResult, PathSegment,
+    SourceLocation, ValidationResult,
+};
+use serde_json::json;
+
+#[cfg(test)]
+mod error_creation_tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_error_creation() {
+        let error = GraphQLError::new("Test error".to_string());
+        assert_eq!(error.message, "Test error");
+        assert!(error.locations.is_empty());
+        assert!(error.path.is_none());
+        assert!(error.extensions.is_none());
+    }
+
+    #[test]
+    fn test_validation_error_with_code() {
+        let error = GraphQLError::validation_error("Invalid field".to_string());
+        assert_eq!(error.message, "Invalid field");
+        assert_eq!(error.error_code(), Some("VALIDATION_ERROR"));
+    }
+
+    #[test]
+    fn test_field_not_found_error() {
+        let error = GraphQLError::field_not_found("name", "User");
+        assert_eq!(error.message, "Field 'name' not found on type 'User'");
+        assert_eq!(error.error_code(), Some("FIELD_NOT_FOUND"));
+        assert!(error.is_client_error());
+    }
+
+    #[test]
+    fn test_auth_error() {
+        let error = GraphQLError::auth_error("Invalid token".to_string());
+        assert_eq!(error.error_code(), Some("AUTH_ERROR"));
+        assert!(error.is_client_error());
+    }
+
+    #[test]
+    fn test_execution_error() {
+        let error = GraphQLError::execution_error("Database connection failed".to_string());
+        assert_eq!(error.error_code(), Some("EXECUTION_ERROR"));
+        assert!(error.is_server_error());
+    }
+
+    #[test]
+    fn test_rate_limit_error() {
+        let error = GraphQLError::rate_limit_error();
+        assert_eq!(error.message, "Rate limit exceeded");
+        assert_eq!(error.error_code(), Some("RATE_LIMIT_EXCEEDED"));
+    }
+}
+
+#[cfg(test)]
+mod error_enhancement_tests {
+    use super::*;
+
+    #[test]
+    fn test_error_with_location() {
+        let error = GraphQLError::new("Test".to_string()).with_location(2, 5);
+
+        assert_eq!(error.locations.len(), 1);
+        assert_eq!(error.locations[0].line, 2);
+        assert_eq!(error.locations[0].column, 5);
+    }
+
+    #[test]
+    fn test_error_with_multiple_locations() {
+        let locations = vec![
+            SourceLocation { line: 1, column: 3 },
+            SourceLocation { line: 4, column: 7 },
+        ];
+
+        let error = GraphQLError::new("Test".to_string()).with_locations(locations.clone());
+
+        assert_eq!(error.locations.len(), 2);
+        assert_eq!(error.locations, locations);
+    }
+
+    #[test]
+    fn test_error_with_path() {
+        let path = vec![
+            PathSegment::Field("user".to_string()),
+            PathSegment::Index(0),
+            PathSegment::Field("name".to_string()),
+        ];
+
+        let error = GraphQLError::new("Test".to_string()).with_path(path.clone());
+
+        assert_eq!(error.path, Some(path));
+    }
+
+    #[test]
+    fn test_error_with_extensions() {
+        let error = GraphQLError::new("Test".to_string())
+            .with_extension("customField", json!("customValue"))
+            .with_timestamp()
+            .with_request_id("req-123");
+
+        let extensions = error.extensions.unwrap();
+        assert_eq!(extensions.get("customField").unwrap(), "customValue");
+        assert!(extensions.contains_key("timestamp"));
+        assert_eq!(extensions.get("requestId").unwrap(), "req-123");
+    }
+
+    #[test]
+    fn test_user_message_masking() {
+        let client_error = GraphQLError::field_not_found("name", "User");
+        assert_eq!(client_error.user_message(true), client_error.message);
+
+        let server_error = GraphQLError::execution_error("Database crashed".to_string());
+        assert_eq!(
+            server_error.user_message(true),
+            "Internal server error occurred"
+        );
+        assert_eq!(server_error.user_message(false), "Database crashed");
+    }
+}
+
+#[cfg(test)]
+mod execution_result_tests {
+    use super::*;
+
+    #[test]
+    fn test_success_result() {
+        let data = json!({"name": "John"});
+        let result = ExecutionResult::success(data.clone());
+
+        assert_eq!(result.data, Some(data));
+        assert!(result.errors.is_empty());
+        assert!(result.is_success());
+        assert!(!result.has_errors());
+    }
+
+    #[test]
+    fn test_error_result() {
+        let errors = vec![GraphQLError::validation_error("Invalid".to_string())];
+        let result = ExecutionResult::error(errors.clone());
+
+        assert_eq!(result.data, None);
+        assert_eq!(result.errors, errors);
+        assert!(!result.is_success());
+        assert!(result.has_errors());
+    }
+
+    #[test]
+    fn test_single_error_result() {
+        let error = GraphQLError::field_not_found("name", "User");
+        let result = ExecutionResult::single_error(error.clone());
+
+        assert_eq!(result.errors.len(), 1);
+        assert_eq!(result.errors[0], error);
+    }
+
+    #[test]
+    fn test_partial_result() {
+        let data = json!({"name": "John", "age": null});
+        let errors = vec![GraphQLError::execution_error(
+            "Age service unavailable".to_string(),
+        )];
+        let result = ExecutionResult::partial(data.clone(), errors.clone());
+
+        assert_eq!(result.data, Some(data));
+        assert_eq!(result.errors, errors);
+        assert!(result.has_errors());
+        assert!(!result.is_success());
+    }
+
+    #[test]
+    fn test_with_error_chaining() {
+        let result = ExecutionResult::success(json!({"test": true}))
+            .with_error(GraphQLError::validation_error("Warning".to_string()));
+
+        assert!(result.data.is_some());
+        assert_eq!(result.errors.len(), 1);
+    }
+
+    #[test]
+    fn test_errors_by_code() {
+        let errors = vec![
+            GraphQLError::validation_error("Error 1".to_string()),
+            GraphQLError::field_not_found("field", "Type"),
+            GraphQLError::validation_error("Error 2".to_string()),
+        ];
+
+        let result = ExecutionResult::error(errors);
+        let validation_errors = result.errors_by_code("VALIDATION_ERROR");
+        let field_errors = result.errors_by_code("FIELD_NOT_FOUND");
+
+        assert_eq!(validation_errors.len(), 2);
+        assert_eq!(field_errors.len(), 1);
+    }
+
+    #[test]
+    fn test_client_server_error_detection() {
+        let result = ExecutionResult::success(json!({}))
+            .with_error(GraphQLError::validation_error("Client error".to_string()))
+            .with_error(GraphQLError::execution_error("Server error".to_string()));
+
+        assert!(result.has_client_errors());
+        assert!(result.has_server_errors());
+    }
+
+    #[test]
+    fn test_result_sanitization() {
+        let result = ExecutionResult::success(json!({"data": "test"}))
+            .with_error(GraphQLError::execution_error(
+                "Sensitive server info".to_string(),
+            ))
+            .with_error(GraphQLError::validation_error("Client error".to_string()));
+
+        let sanitized = result.sanitized(true);
+
+        // Server error should be masked
+        assert!(sanitized.errors[0]
+            .message
+            .contains("Internal server error"));
+        // Client error should remain unchanged
+        assert_eq!(sanitized.errors[1].message, "Client error");
+    }
+}
+
+#[cfg(test)]
+mod validation_result_tests {
+    use super::*;
+
+    #[test]
+    fn test_validation_result_states() {
+        let valid = ValidationResult::valid();
+        let invalid = ValidationResult::invalid("Error".to_string());
+        let pending = ValidationResult::Pending;
+
+        assert!(valid.is_valid());
+        assert!(!valid.is_invalid());
+        assert!(!valid.is_pending());
+
+        assert!(!invalid.is_valid());
+        assert!(invalid.is_invalid());
+        assert!(!invalid.is_pending());
+
+        assert!(!pending.is_valid());
+        assert!(!pending.is_invalid());
+        assert!(pending.is_pending());
+    }
+
+    #[test]
+    fn test_field_error() {
+        let result = ValidationResult::field_error("name", "Required field".to_string());
+
+        if let ValidationResult::Invalid(errors) = result {
+            assert_eq!(errors.len(), 1);
+            assert_eq!(errors[0].message, "Required field");
+            assert_eq!(
+                errors[0].path,
+                Some(vec![PathSegment::Field("name".to_string())])
+            );
+        } else {
+            panic!("Expected Invalid result");
+        }
+    }
+
+    #[test]
+    fn test_type_error() {
+        let result = ValidationResult::type_error("User", "Invalid type definition".to_string());
+
+        if let ValidationResult::Invalid(errors) = result {
+            assert_eq!(errors.len(), 1);
+            let extensions = errors[0].extensions.as_ref().unwrap();
+            assert_eq!(extensions.get("type").unwrap(), "User");
+        } else {
+            panic!("Expected Invalid result");
+        }
+    }
+
+    #[test]
+    fn test_combine_validation_results() {
+        let results = vec![
+            ValidationResult::valid(),
+            ValidationResult::invalid("Error 1".to_string()),
+            ValidationResult::valid(),
+            ValidationResult::invalid("Error 2".to_string()),
+        ];
+
+        let combined = ValidationResult::combine(results);
+
+        if let ValidationResult::Invalid(errors) = combined {
+            assert_eq!(errors.len(), 2);
+        } else {
+            panic!("Expected combined Invalid result");
+        }
+    }
+
+    #[test]
+    fn test_combine_with_pending() {
+        let results = vec![
+            ValidationResult::valid(),
+            ValidationResult::Pending,
+            ValidationResult::invalid("Error".to_string()),
+        ];
+
+        let combined = ValidationResult::combine(results);
+        assert!(combined.is_pending());
+    }
+
+    #[test]
+    fn test_with_error_chaining() {
+        let result = ValidationResult::valid()
+            .with_error(GraphQLError::validation_error("New error".to_string()));
+
+        if let ValidationResult::Invalid(errors) = result {
+            assert_eq!(errors.len(), 1);
+        } else {
+            panic!("Expected Invalid result");
+        }
+    }
+
+    #[test]
+    fn test_to_execution_result() {
+        let validation_error = ValidationResult::invalid("Test error".to_string());
+        let execution_result = validation_error.to_execution_result().unwrap();
+
+        assert!(execution_result.data.is_none());
+        assert_eq!(execution_result.errors.len(), 1);
+        assert_eq!(execution_result.errors[0].message, "Test error");
+    }
+}
+
+#[cfg(test)]
+mod error_propagation_tests {
+    use super::*;
+
+    #[test]
+    fn test_propagate_nullable_field_error() {
+        let error = GraphQLError::field_not_found("name", "User");
+        let path = vec![PathSegment::Field("user".to_string())];
+
+        let (propagated_error, should_bubble) = ErrorPropagation::propagate_field_error(
+            error.clone(),
+            &path,
+            true, // nullable
+        );
+
+        assert_eq!(propagated_error.path, Some(path));
+        assert!(!should_bubble); // Nullable fields don't bubble
+    }
+
+    #[test]
+    fn test_propagate_non_nullable_field_error() {
+        let error = GraphQLError::execution_error("Service failed".to_string());
+        let path = vec![PathSegment::Field("user".to_string())];
+
+        let (propagated_error, should_bubble) = ErrorPropagation::propagate_field_error(
+            error.clone(),
+            &path,
+            false, // non-nullable
+        );
+
+        assert_eq!(propagated_error.path, Some(path));
+        assert!(should_bubble); // Non-nullable fields bubble up
+    }
+
+    #[test]
+    fn test_collect_field_errors() {
+        let errors = vec![
+            (GraphQLError::validation_error("Error 1".to_string()), false),
+            (GraphQLError::execution_error("Error 2".to_string()), true),
+            (GraphQLError::field_not_found("field", "Type"), false),
+        ];
+
+        let (collected_errors, should_bubble) = ErrorPropagation::collect_field_errors(errors);
+
+        assert_eq!(collected_errors.len(), 3);
+        assert!(should_bubble); // One error had bubble=true
+    }
+
+    #[test]
+    fn test_missing_required_field() {
+        let parent_path = vec![PathSegment::Field("user".to_string())];
+        let error = ErrorPropagation::missing_required_field("id", &parent_path);
+
+        assert!(error.message.contains("Required field 'id' is missing"));
+        assert_eq!(
+            error.path,
+            Some(vec![
+                PathSegment::Field("user".to_string()),
+                PathSegment::Field("id".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_null_in_non_nullable() {
+        let parent_path = vec![PathSegment::Field("user".to_string())];
+        let error = ErrorPropagation::null_in_non_nullable("name", &parent_path);
+
+        assert!(error
+            .message
+            .contains("Cannot return null for non-nullable field 'name'"));
+        assert_eq!(
+            error.path,
+            Some(vec![
+                PathSegment::Field("user".to_string()),
+                PathSegment::Field("name".to_string()),
+            ])
+        );
+    }
+}
+
+#[cfg(test)]
+mod error_formatting_tests {
+    use super::*;
+
+    #[test]
+    fn test_development_formatting() {
+        let error = GraphQLError::execution_error("Test error".to_string())
+            .with_location(2, 5)
+            .with_path(vec![PathSegment::Field("test".to_string())])
+            .with_extension("stackTrace", json!(["line1", "line2"]));
+
+        let formatted = ErrorFormatter::format_development(&error);
+
+        assert_eq!(formatted["message"], "Test error");
+        assert_eq!(formatted["locations"][0]["line"], 2);
+        assert_eq!(formatted["path"][0], "test");
+        assert!(formatted["stackTrace"].is_array());
+    }
+
+    #[test]
+    fn test_production_formatting() {
+        let server_error = GraphQLError::execution_error("Sensitive info".to_string())
+            .with_location(2, 5)
+            .with_timestamp();
+
+        let formatted = ErrorFormatter::format_production(&server_error);
+
+        assert_eq!(formatted["message"], "Internal server error occurred");
+        assert!(formatted["locations"].is_null()); // Hidden for server errors
+        assert!(formatted["extensions"]["code"].is_string());
+        assert!(formatted["extensions"]["timestamp"].is_number());
+    }
+
+    #[test]
+    fn test_error_summary() {
+        let errors = vec![
+            GraphQLError::validation_error("Error 1".to_string()),
+            GraphQLError::validation_error("Error 2".to_string()),
+            GraphQLError::execution_error("Error 3".to_string()),
+            GraphQLError::field_not_found("field", "Type"),
+        ];
+
+        let summary = ErrorFormatter::format_error_summary(&errors);
+
+        assert_eq!(summary["total"], 4);
+        assert_eq!(summary["client_errors"], 3);
+        assert_eq!(summary["server_errors"], 1);
+
+        let by_code = &summary["by_code"];
+        assert_eq!(by_code["VALIDATION_ERROR"], 2);
+        assert_eq!(by_code["EXECUTION_ERROR"], 1);
+        assert_eq!(by_code["FIELD_NOT_FOUND"], 1);
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+
+    #[test]
+    fn test_complete_error_workflow() {
+        // Start with validation
+        let mut validation_errors = vec![
+            GraphQLError::field_not_found("unknownField", "Query"),
+            GraphQLError::validation_error("Missing required argument".to_string()),
+        ];
+
+        // Add location info
+        validation_errors[0] = validation_errors[0].clone().with_location(1, 10);
+        validation_errors[1] = validation_errors[1].clone().with_location(1, 25);
+
+        let validation_result = ValidationResult::invalid_with_errors(validation_errors);
+
+        // Convert to execution result
+        let execution_result = validation_result.to_execution_result().unwrap();
+
+        // Add execution timing
+        let final_result = execution_result.with_timing(150);
+
+        // Verify the complete workflow
+        assert!(final_result.has_errors());
+        assert!(final_result.has_client_errors());
+        assert!(!final_result.has_server_errors());
+        assert_eq!(final_result.errors.len(), 2);
+
+        let timing_ext = final_result.extensions.unwrap();
+        assert_eq!(timing_ext["timing"]["duration_ms"], 150);
+    }
+
+    #[test]
+    fn test_graphql_result_type_alias() {
+        fn sample_operation() -> GraphQLResult<String> {
+            Err(GraphQLError::validation_error("Sample error".to_string()))
+        }
+
+        match sample_operation() {
+            Ok(_) => panic!("Should have failed"),
+            Err(error) => {
+                assert_eq!(error.error_code(), Some("VALIDATION_ERROR"));
+            },
+        }
+    }
+}


### PR DESCRIPTION
### Summary

This PR implements a comprehensive error handling system for the GraphQL server, following the patterns established in the documentation.

### Key Features

- **Enhanced GraphQLError**: Typed error creation methods, error codes, timestamps, and extensions
- **Error Categorization**: Client vs server error classification with appropriate masking
- **ExecutionResult Improvements**: Partial results, error chaining, sanitization for production
- **ValidationResult Enhancements**: Field errors, type errors, result combination
- **Error Propagation**: Utilities for proper field error bubbling (nullable vs non-nullable)
- **Error Formatting**: Development vs production formatting with security considerations
- **Comprehensive Testing**: 36 test cases covering all error handling scenarios
- **Working Example**: `enhanced_error_handling_demo.rs` showcasing all capabilities

### Implementation Details

- Added typed error constructors: `field_not_found()`, `auth_error()`, `execution_error()`, etc.
- Error codes automatically assigned and accessible via `error_code()` method
- Client/server error detection with `is_client_error()` and `is_server_error()` 
- Production error masking to prevent sensitive information leakage
- Error extensions for additional metadata (timestamps, request IDs, suggestions)
- Field error path tracking for precise error location reporting
- Error propagation following GraphQL spec (non-nullable field errors bubble up)

### Testing

- All existing tests continue to pass (61 + 36 new = 97 total tests)
- Comprehensive error handling test suite covers edge cases and integration scenarios
- Working demo shows real-world usage patterns

### Checklist

- [x] Enhanced error types and creation methods
- [x] Error propagation and formatting utilities
- [x] Comprehensive test coverage
- [x] Working example demonstrating capabilities
- [x] All tests passing
- [x] Code formatting and basic clippy checks
- [x] Documentation updated in previous PR

Closes #7
